### PR TITLE
fixing path segments for keycloak 21.0.1

### DIFF
--- a/src/main/java/cd/go/authorization/keycloak/KeycloakApiClient.java
+++ b/src/main/java/cd/go/authorization/keycloak/KeycloakApiClient.java
@@ -60,7 +60,6 @@ public class KeycloakApiClient {
 
         return HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
                 .newBuilder()
-                .addPathSegments("auth")
                 .addPathSegments("realms")
                 .addPathSegments(realm)
                 .addPathSegments("protocol")
@@ -86,7 +85,6 @@ public class KeycloakApiClient {
 
         final String accessTokenUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
                 .newBuilder()
-                .addPathSegments("auth")
                 .addPathSegments("realms")
                 .addPathSegments(realm)
                 .addPathSegments("protocol")
@@ -118,7 +116,6 @@ public class KeycloakApiClient {
 
         final String userProfileUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
                 .newBuilder()
-                .addPathSegments("auth")
                 .addPathSegments("realms")
                 .addPathSegments(realm)
                 .addPathSegments("protocol")

--- a/src/test/java/cd/go/authorization/keycloak/KeycloakApiClientTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/KeycloakApiClientTest.java
@@ -73,7 +73,7 @@ public class KeycloakApiClientTest {
     public void shouldReturnAuthorizationServerUrl() throws Exception {
         final String authorizationServerUrl = KeycloakApiClient.authorizationServerUrl("call-back-url");
 
-        assertThat(authorizationServerUrl, startsWith("https://example.com/auth/realms/master/protocol/openid-connect/auth?client_id=client-id&redirect_uri=call-back-url&response_type=code&scope=openid%20profile%20email%20roles&state="));
+        assertThat(authorizationServerUrl, startsWith("https://example.com/realms/master/protocol/openid-connect/auth?client_id=client-id&redirect_uri=call-back-url&response_type=code&scope=openid%20profile%20email%20roles&state="));
     }
 
     @Test
@@ -89,7 +89,7 @@ public class KeycloakApiClientTest {
         assertThat(tokenInfo.accessToken(), is("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9"));
 
         RecordedRequest request = server.takeRequest();
-        assertEquals("POST /auth/realms/master/protocol/openid-connect/token HTTP/1.1", request.getRequestLine());
+        assertEquals("POST /realms/master/protocol/openid-connect/token HTTP/1.1", request.getRequestLine());
         assertEquals("application/x-www-form-urlencoded", request.getHeader("Content-Type"));
         assertEquals("client_id=client-id&client_secret=client-secret&code=some-code&grant_type=authorization_code&redirect_uri=callback-url", request.getBody().readUtf8());
     }
@@ -108,7 +108,7 @@ public class KeycloakApiClientTest {
         assertThat(KeycloakUser.getEmail(), is("foo@bar.com"));
 
         RecordedRequest request = server.takeRequest();
-        assertEquals("GET /auth/realms/master/protocol/openid-connect/userinfo HTTP/1.1", request.getRequestLine());
+        assertEquals("GET /realms/master/protocol/openid-connect/userinfo HTTP/1.1", request.getRequestLine());
         assertEquals("Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9", request.getHeader("Authorization"));
     }
 
@@ -121,7 +121,7 @@ public class KeycloakApiClientTest {
         when(KeycloakConfiguration.keycloakEndpoint()).thenReturn(server.url("/").toString());
 
         thrown.expect(RuntimeException.class);
-        thrown.expectMessage("Api call to `/auth/realms/master/protocol/openid-connect/userinfo` failed with error: `Unauthorized`");
+        thrown.expectMessage("Api call to `/realms/master/protocol/openid-connect/userinfo` failed with error: `Unauthorized`");
 
         KeycloakApiClient.userProfile(tokenInfo);
     }


### PR DESCRIPTION
Hi!
Thank you for your great work.  This minor patch works nicely for keycloak 21.0.1 talking to gocd 23.1.0-16079 -- the path-segment 'auth' was removed in the newer keycloak version.

Best,
ddhh83