### PR TITLE
Feature: configure keycloak context path or not

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -16,3 +16,4 @@ jobs:
           java-version: 11
           distribution: temurin
       - name: Build with Gradle
+        run: ./gradlew assemble check

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -1,19 +1,18 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-#name: Testing For PRs
+name: Testing For PRs
 
-#on: [ pull_request ]
+on: [ pull_request ]
 
-#jobs:
-#  test:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: 17
-#          distribution: temurin
-#      - name: Build with Gradle
-#
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: temurin
+      - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply from: "https://raw.githubusercontent.com/gocd/gocd-plugin-gradle-task-help
 gocdPlugin {
     id = 'cd.go.authorization.keycloak'
     pluginVersion = '2.0.0'
-    goCdVersion = '19.2.0'
+    goCdVersion = '23.3.0'
     name = 'Keycloak oauth authorization plugin'
     description = 'Keycloak oauth authorization plugin for GoCD'
     vendorName = 'klinux'

--- a/docs/AUTHORIZATION_CONFIGURATION.md
+++ b/docs/AUTHORIZATION_CONFIGURATION.md
@@ -7,6 +7,7 @@ The `Authorization Configuration` is used to configure a connection to an Keyclo
 3. Provide a unique identifier for this authorization configuration and select `Keycloak oauth authorization plugin` as the **Plugin**.
 
 4. **Keycloak Endpoint (`Mandatory`):** Specify your Keycloak Endpoint.
+> If you have the context /auth in you Keycloak, set the context path in Endpoint config.
 
     ![Keycloak Endpoint](images/keycloak_endpoint.png?raw=true "Keycloak Endpoint")
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-* GoCD server version v17.5.0 or above
+* GoCD server version v17.5.0 for version 1.0.x and 23.3.0 for 2.0.x.
 * Keycloak [API documentation](https://www.keycloak.org/docs-api/11.0/rest-api/index.html)
 
 ## Installation

--- a/gocd/docker-compose.yaml
+++ b/gocd/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       volumes:
         - data:/opt/jboss/keycloak/standalone/data
   gocd:
-    image: gocd/gocd-server:v22.3.0
+    image: gocd/gocd-server:v23.3.0
     volumes:
       - data:/godata
       - ./plugins:/godata/plugins

--- a/src/main/java/cd/go/authorization/keycloak/KeycloakApiClient.java
+++ b/src/main/java/cd/go/authorization/keycloak/KeycloakApiClient.java
@@ -62,45 +62,25 @@ public class KeycloakApiClient {
         LOG.debug("[KeycloakApiClient] Generating Keycloak oauth url.");
         String realm = keycloakConfiguration.keycloakRealm();
 
-        // TODO: get better solution for this validate
-        if (keycloakConfiguration.keycloakContextPath()) {
-            return HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
-                    .newBuilder()
-                    .addPathSegments("auth")
-                    .addPathSegments("realms")
-                    .addPathSegments(realm)
-                    .addPathSegments("protocol")
-                    .addPathSegments("openid-connect")
-                    .addPathSegments("auth")
-                    .addQueryParameter("client_id", keycloakConfiguration.clientId())
-                    .addQueryParameter("redirect_uri", callbackUrl)
-                    .addQueryParameter("response_type", "code")
-                    .addQueryParameter("scope", keycloakConfiguration.keycloakScopes())
-                    .addQueryParameter("state", UUID.randomUUID().toString())
-                    .addQueryParameter("nonce", UUID.randomUUID().toString())
-                    .build().toString();
-        } else {
-            return HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
-                    .newBuilder()
-                    .addPathSegments("realms")
-                    .addPathSegments(realm)
-                    .addPathSegments("protocol")
-                    .addPathSegments("openid-connect")
-                    .addPathSegments("auth")
-                    .addQueryParameter("client_id", keycloakConfiguration.clientId())
-                    .addQueryParameter("redirect_uri", callbackUrl)
-                    .addQueryParameter("response_type", "code")
-                    .addQueryParameter("scope", keycloakConfiguration.keycloakScopes())
-                    .addQueryParameter("state", UUID.randomUUID().toString())
-                    .addQueryParameter("nonce", UUID.randomUUID().toString())
-                    .build().toString();
-        }
+        return HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
+                .newBuilder()
+                .addPathSegments("realms")
+                .addPathSegments(realm)
+                .addPathSegments("protocol")
+                .addPathSegments("openid-connect")
+                .addPathSegments("auth")
+                .addQueryParameter("client_id", keycloakConfiguration.clientId())
+                .addQueryParameter("redirect_uri", callbackUrl)
+                .addQueryParameter("response_type", "code")
+                .addQueryParameter("scope", keycloakConfiguration.keycloakScopes())
+                .addQueryParameter("state", UUID.randomUUID().toString())
+                .addQueryParameter("nonce", UUID.randomUUID().toString())
+                .build().toString();
     }
 
     public TokenInfo fetchAccessToken(Map<String, String> params) throws Exception {
         String realm = keycloakConfiguration.keycloakRealm();
         final String code = params.get("code");
-        final String accessTokenUrl;
 
         if (isBlank(code)) {
             throw new RuntimeException("[KeycloakApiClient] Authorization code must not be null.");
@@ -108,28 +88,14 @@ public class KeycloakApiClient {
 
         LOG.debug("[KeycloakApiClient] Fetching access token using authorization code.");
 
-        // TODO: get better solution for this validate
-        if (keycloakConfiguration.keycloakContextPath()) {
-            LOG.debug("[KeycloakApiClient] context path config: " + keycloakConfiguration.keycloakContextPath().toString());
-            accessTokenUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
-                    .newBuilder()
-                    .addPathSegments("auth")
-                    .addPathSegments("realms")
-                    .addPathSegments(realm)
-                    .addPathSegments("protocol")
-                    .addPathSegments("openid-connect")
-                    .addPathSegments("token")
-                    .build().toString();
-        } else {
-            accessTokenUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
-                    .newBuilder()
-                    .addPathSegments("realms")
-                    .addPathSegments(realm)
-                    .addPathSegments("protocol")
-                    .addPathSegments("openid-connect")
-                    .addPathSegments("token")
-                    .build().toString();
-        }
+        final String accessTokenUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
+                .newBuilder()
+                .addPathSegments("realms")
+                .addPathSegments(realm)
+                .addPathSegments("protocol")
+                .addPathSegments("openid-connect")
+                .addPathSegments("token")
+                .build().toString();
 
         final FormBody formBody = new FormBody.Builder()
                 .add("client_id", keycloakConfiguration.clientId())
@@ -151,7 +117,6 @@ public class KeycloakApiClient {
         validateTokenInfo(tokenInfo);
         String accessToken = tokenInfo.accessToken();
         String realm = keycloakConfiguration.keycloakRealm();
-        final String userProfileUrl;
 
         // Check status of token
         LOG.debug("[KeycloakApiClient] Token Before: " + tokenInfo.accessToken());
@@ -165,27 +130,14 @@ public class KeycloakApiClient {
 
         LOG.debug("[KeycloakApiClient] Fetching user profile using access token.");
 
-        // TODO: get better solution for this validate
-        if (keycloakConfiguration.keycloakContextPath()) {
-            userProfileUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
-                    .newBuilder()
-                    .addPathSegments("auth")
-                    .addPathSegments("realms")
-                    .addPathSegments(realm)
-                    .addPathSegments("protocol")
-                    .addPathSegments("openid-connect")
-                    .addPathSegments("userinfo")
-                    .toString();
-        } else {
-            userProfileUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
-                    .newBuilder()
-                    .addPathSegments("realms")
-                    .addPathSegments(realm)
-                    .addPathSegments("protocol")
-                    .addPathSegments("openid-connect")
-                    .addPathSegments("userinfo")
-                    .toString();
-        }
+        final String userProfileUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
+                .newBuilder()
+                .addPathSegments("realms")
+                .addPathSegments(realm)
+                .addPathSegments("protocol")
+                .addPathSegments("openid-connect")
+                .addPathSegments("userinfo")
+                .toString();
 
         final Request request = new Request.Builder()
                 .url(userProfileUrl)
@@ -225,31 +177,16 @@ public class KeycloakApiClient {
         String client = keycloakConfiguration.clientId();
         String secret = keycloakConfiguration.clientSecret();
         String basicEncode = Base64.getEncoder().encodeToString((client + ":" + secret).getBytes());
-        final String introspectUrl;
 
-        // TODO: get better solution for this validate
-        if (keycloakConfiguration.keycloakContextPath()) {
-            introspectUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
-                    .newBuilder()
-                    .addPathSegments("auth")
-                    .addPathSegments("realms")
-                    .addPathSegments(realm)
-                    .addPathSegments("protocol")
-                    .addPathSegments("openid-connect")
-                    .addPathSegments("token")
-                    .addPathSegments("introspect")
-                    .toString();
-        } else {
-            introspectUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
-                    .newBuilder()
-                    .addPathSegments("realms")
-                    .addPathSegments(realm)
-                    .addPathSegments("protocol")
-                    .addPathSegments("openid-connect")
-                    .addPathSegments("token")
-                    .addPathSegments("introspect")
-                    .toString();
-        }
+        final String introspectUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
+                .newBuilder()
+                .addPathSegments("realms")
+                .addPathSegments(realm)
+                .addPathSegments("protocol")
+                .addPathSegments("openid-connect")
+                .addPathSegments("token")
+                .addPathSegments("introspect")
+                .toString();
 
         final FormBody formBody = new FormBody.Builder()
                 .add("token", token)
@@ -278,29 +215,15 @@ public class KeycloakApiClient {
         String client = keycloakConfiguration.clientId();
         String secret = keycloakConfiguration.clientSecret();
         String basicEncode = Base64.getEncoder().encodeToString((client + ":" + secret).getBytes());
-        final String refreshTokenUrl;
-
-        // TODO: get better solution for this validate
-        if (keycloakConfiguration.keycloakContextPath()) {
-            refreshTokenUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
-                    .newBuilder()
-                    .addPathSegments("auth")
-                    .addPathSegments("realms")
-                    .addPathSegments(realm)
-                    .addPathSegments("protocol")
-                    .addPathSegments("openid-connect")
-                    .addPathSegments("token")
-                    .build().toString();
-        } else {
-            refreshTokenUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
-                    .newBuilder()
-                    .addPathSegments("realms")
-                    .addPathSegments(realm)
-                    .addPathSegments("protocol")
-                    .addPathSegments("openid-connect")
-                    .addPathSegments("token")
-                    .build().toString();
-        }
+        
+        final String refreshTokenUrl = HttpUrl.parse(keycloakConfiguration.keycloakEndpoint())
+                .newBuilder()
+                .addPathSegments("realms")
+                .addPathSegments(realm)
+                .addPathSegments("protocol")
+                .addPathSegments("openid-connect")
+                .addPathSegments("token")
+                .build().toString();
 
         final FormBody formBody = new FormBody.Builder()
                 .add("grant_type", "refresh_token")

--- a/src/main/java/cd/go/authorization/keycloak/models/KeycloakConfiguration.java
+++ b/src/main/java/cd/go/authorization/keycloak/models/KeycloakConfiguration.java
@@ -34,6 +34,11 @@ public class KeycloakConfiguration implements Validatable {
     private String keycloakEndpoint;
 
     @Expose
+    @SerializedName("KeycloakContextPath")
+    @ProfileField(key = "KeycloakContextPath", required = true, secure = false)
+    private Boolean keycloakContextPath;
+
+    @Expose
     @SerializedName("KeycloakRealm")
     @ProfileField(key = "KeycloakRealm", required = true, secure = false)
     private String keycloakRealm;
@@ -47,6 +52,11 @@ public class KeycloakConfiguration implements Validatable {
     @SerializedName("ClientSecret")
     @ProfileField(key = "ClientSecret", required = true, secure = true)
     private String clientSecret;
+
+    @Expose
+    @SerializedName("KeycloakScopes")
+    @ProfileField(key = "KeycloakScopes", required = true, secure = false)
+    private String keycloakScopes;
 
     private KeycloakApiClient keycloakApiClient;
 
@@ -63,6 +73,10 @@ public class KeycloakConfiguration implements Validatable {
         return keycloakEndpoint;
     }
 
+    public Boolean keycloakContextPath() {
+        return keycloakContextPath;
+    }
+
     public String keycloakRealm() {
         return keycloakRealm;
     }
@@ -73,6 +87,10 @@ public class KeycloakConfiguration implements Validatable {
 
     public String clientSecret() {
         return clientSecret;
+    }
+
+    public String keycloakScopes() {
+        return keycloakScopes;
     }
 
     public String toJSON() {

--- a/src/main/java/cd/go/authorization/keycloak/models/KeycloakConfiguration.java
+++ b/src/main/java/cd/go/authorization/keycloak/models/KeycloakConfiguration.java
@@ -34,11 +34,6 @@ public class KeycloakConfiguration implements Validatable {
     private String keycloakEndpoint;
 
     @Expose
-    @SerializedName("KeycloakContextPath")
-    @ProfileField(key = "KeycloakContextPath", required = true, secure = false)
-    private Boolean keycloakContextPath;
-
-    @Expose
     @SerializedName("KeycloakRealm")
     @ProfileField(key = "KeycloakRealm", required = true, secure = false)
     private String keycloakRealm;
@@ -71,10 +66,6 @@ public class KeycloakConfiguration implements Validatable {
 
     public String keycloakEndpoint() {
         return keycloakEndpoint;
-    }
-
-    public Boolean keycloakContextPath() {
-        return keycloakContextPath;
     }
 
     public String keycloakRealm() {

--- a/src/main/resource-templates/plugin.xml
+++ b/src/main/resource-templates/plugin.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<go-plugin id="${id}" version="1">
+<go-plugin id="${id}" version="2">
     <about>
         <name>${name}</name>
         <version>${version}</version>

--- a/src/main/resources-generated/plugin.properties
+++ b/src/main/resources-generated/plugin.properties
@@ -16,7 +16,7 @@
 
 id=cd.go.authorization.keycloak
 name=Keycloak oauth authorization plugin
-version=2.0.0-21
+version=2.0.0-22
 goCdVersion=23.3.0
 description=Keycloak oauth authorization plugin for GoCD
 vendorName=klinux

--- a/src/main/resources-generated/plugin.properties
+++ b/src/main/resources-generated/plugin.properties
@@ -16,8 +16,8 @@
 
 id=cd.go.authorization.keycloak
 name=Keycloak oauth authorization plugin
-version=2.0.0-19
-goCdVersion=19.2.0
+version=2.0.0-21
+goCdVersion=23.3.0
 description=Keycloak oauth authorization plugin for GoCD
 vendorName=klinux
 vendorUrl=https://github.com/klinux/gocd-keycloak-oauth-authorization-plugin

--- a/src/main/resources-generated/plugin.properties
+++ b/src/main/resources-generated/plugin.properties
@@ -16,7 +16,7 @@
 
 id=cd.go.authorization.keycloak
 name=Keycloak oauth authorization plugin
-version=2.0.0-22
+version=2.0.0-23
 goCdVersion=23.3.0
 description=Keycloak oauth authorization plugin for GoCD
 vendorName=klinux

--- a/src/main/resources-generated/plugin.xml
+++ b/src/main/resources-generated/plugin.xml
@@ -17,7 +17,7 @@
 <go-plugin id="cd.go.authorization.keycloak" version="1">
   <about>
     <name>Keycloak oauth authorization plugin</name>
-    <version>2.0.0-22</version>
+    <version>2.0.0-23</version>
     <target-go-version>23.3.0</target-go-version>
     <description>Keycloak oauth authorization plugin for GoCD</description>
     <vendor>

--- a/src/main/resources-generated/plugin.xml
+++ b/src/main/resources-generated/plugin.xml
@@ -17,8 +17,8 @@
 <go-plugin id="cd.go.authorization.keycloak" version="1">
   <about>
     <name>Keycloak oauth authorization plugin</name>
-    <version>2.0.0-19</version>
-    <target-go-version>19.2.0</target-go-version>
+    <version>2.0.0-21</version>
+    <target-go-version>23.3.0</target-go-version>
     <description>Keycloak oauth authorization plugin for GoCD</description>
     <vendor>
       <name>klinux</name>

--- a/src/main/resources-generated/plugin.xml
+++ b/src/main/resources-generated/plugin.xml
@@ -17,7 +17,7 @@
 <go-plugin id="cd.go.authorization.keycloak" version="1">
   <about>
     <name>Keycloak oauth authorization plugin</name>
-    <version>2.0.0-21</version>
+    <version>2.0.0-22</version>
     <target-go-version>23.3.0</target-go-version>
     <description>Keycloak oauth authorization plugin for GoCD</description>
     <vendor>

--- a/src/main/resources/auth-config.template.html
+++ b/src/main/resources/auth-config.template.html
@@ -98,6 +98,19 @@
     </div>
 
     <div class="form_item_block">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[KeycloakContextPath].$error.server}">Keycloak Context Path:<span class='asterix'>*</span>
+            <div class="tooltip-info">
+              <span class="tooltip-content">
+                Enable /auth Keycloak context path. In old keycloak versions, the /auth context is default. Disable it if you want to use Keycloak without this context path.
+              </span>
+            </div>
+        </label>
+        <input type="radio" ng-model="KeycloakContextPath" value="true" checked /> True
+        <input type="radio" ng-model="KeycloakContextPath" value="false" /> False
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[KeycloakContextPath].$error.server}" ng-show="GOINPUTNAME[KeycloakContextPath].$error.server">{{GOINPUTNAME[KeycloakContextPath].$error.server}}</span>
+    </div>
+
+    <div class="form_item_block">
         <label ng-class="{'is-invalid-label': GOINPUTNAME[KeycloakRealm].$error.server}">Keycloak Realm:<span class='asterix'>*</span>
             <div class="tooltip-info">
               <span class="tooltip-content">
@@ -132,4 +145,17 @@
         <input ng-class="{'is-invalid-input': GOINPUTNAME[ClientSecret].$error.server}" type="password" ng-model="ClientSecret" ng-required="true"/>
         <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[ClientSecret].$error.server}" ng-show="GOINPUTNAME[ClientSecret].$error.server">{{GOINPUTNAME[ClientSecret].$error.server}}</span>
     </div>
+
+    <div class="form_item_block">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[KeycloakScopes].$error.server}">Keycloak Scopes:<span class='asterix'>*</span>
+            <div class="tooltip-info">
+              <span class="tooltip-content">
+                Set the scopes that you be requested to Keycloak. Default: openid profile email groups roles
+              </span>
+            </div>
+        </label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[KeycloakScopes].$error.server}" type="text" ng-model="KeycloakScopes" value="openid profile email groups roles" ng-required="true"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[KeycloakScopes].$error.server}" ng-show="GOINPUTNAME[KeycloakScopes].$error.server">{{GOINPUTNAME[KeycloakScopes].$error.server}}</span>
+    </div>
+
 </div>

--- a/src/main/resources/auth-config.template.html
+++ b/src/main/resources/auth-config.template.html
@@ -89,25 +89,12 @@
         <label ng-class="{'is-invalid-label': GOINPUTNAME[KeycloakEndpoint].$error.server}">Keycloak Endpoint:<span class='asterix'>*</span>
             <div class="tooltip-info">
               <span class="tooltip-content">
-                Your Keycloak authentication endpoint.
+                Your Keycloak authentication endpoint. If you have the context path /auth in you Keycloak, put the context here.
               </span>
             </div>
         </label>
         <input ng-class="{'is-invalid-input': GOINPUTNAME[KeycloakEndpoint].$error.server}" type="text" ng-model="KeycloakEndpoint" ng-required="true"/>
         <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[KeycloakEndpoint].$error.server}" ng-show="GOINPUTNAME[KeycloakEndpoint].$error.server">{{GOINPUTNAME[KeycloakEndpoint].$error.server}}</span>
-    </div>
-
-    <div class="form_item_block">
-        <label ng-class="{'is-invalid-label': GOINPUTNAME[KeycloakContextPath].$error.server}">Keycloak Context Path:<span class='asterix'>*</span>
-            <div class="tooltip-info">
-              <span class="tooltip-content">
-                Enable /auth Keycloak context path. In old keycloak versions, the /auth context is default. Disable it if you want to use Keycloak without this context path.
-              </span>
-            </div>
-        </label>
-        <input type="radio" ng-model="KeycloakContextPath" value="true" checked /> True
-        <input type="radio" ng-model="KeycloakContextPath" value="false" /> False
-        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[KeycloakContextPath].$error.server}" ng-show="GOINPUTNAME[KeycloakContextPath].$error.server">{{GOINPUTNAME[KeycloakContextPath].$error.server}}</span>
     </div>
 
     <div class="form_item_block">

--- a/src/test/java/cd/go/authorization/keycloak/KeycloakApiClientTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/KeycloakApiClientTest.java
@@ -25,7 +25,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 
 import java.util.Collections;
@@ -33,7 +32,7 @@ import java.util.Collections;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -44,9 +43,6 @@ public class KeycloakApiClientTest {
     private MockWebServer server;
     private KeycloakApiClient KeycloakApiClient;
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Before
     public void setUp() throws Exception {
         initMocks(this);
@@ -55,9 +51,11 @@ public class KeycloakApiClientTest {
         server.start();
 
         when(KeycloakConfiguration.keycloakEndpoint()).thenReturn("https://example.com");
+        when(KeycloakConfiguration.keycloakContextPath()).thenReturn(true);
         when(KeycloakConfiguration.keycloakRealm()).thenReturn("master");
         when(KeycloakConfiguration.clientId()).thenReturn("client-id");
         when(KeycloakConfiguration.clientSecret()).thenReturn("client-secret");
+        when(KeycloakConfiguration.keycloakScopes()).thenReturn("openid profile email groups roles");
 
         CallbackURL.instance().updateRedirectURL("callback-url");
 

--- a/src/test/java/cd/go/authorization/keycloak/KeycloakApiClientTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/KeycloakApiClientTest.java
@@ -51,7 +51,6 @@ public class KeycloakApiClientTest {
         server.start();
 
         when(KeycloakConfiguration.keycloakEndpoint()).thenReturn("https://example.com");
-        when(KeycloakConfiguration.keycloakContextPath()).thenReturn(true);
         when(KeycloakConfiguration.keycloakRealm()).thenReturn("master");
         when(KeycloakConfiguration.clientId()).thenReturn("client-id");
         when(KeycloakConfiguration.clientSecret()).thenReturn("client-secret");
@@ -71,7 +70,7 @@ public class KeycloakApiClientTest {
     public void shouldReturnAuthorizationServerUrl() throws Exception {
         final String authorizationServerUrl = KeycloakApiClient.authorizationServerUrl("call-back-url");
 
-        assertThat(authorizationServerUrl, startsWith("https://example.com/auth/realms/master/protocol/openid-connect/auth?client_id=client-id&redirect_uri=call-back-url&response_type=code&scope=openid%20profile%20email%20groups%20roles&state="));
+        assertThat(authorizationServerUrl, startsWith("https://example.com/realms/master/protocol/openid-connect/auth?client_id=client-id&redirect_uri=call-back-url&response_type=code&scope=openid%20profile%20email%20groups%20roles&state="));
     }
 
     @Test
@@ -87,7 +86,7 @@ public class KeycloakApiClientTest {
         assertThat(tokenInfo.accessToken(), is("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9"));
 
         RecordedRequest request = server.takeRequest();
-        assertEquals("POST /auth/realms/master/protocol/openid-connect/token HTTP/1.1", request.getRequestLine());
+        assertEquals("POST /realms/master/protocol/openid-connect/token HTTP/1.1", request.getRequestLine());
         assertEquals("application/x-www-form-urlencoded", request.getHeader("Content-Type"));
         assertEquals("client_id=client-id&client_secret=client-secret&code=some-code&grant_type=authorization_code&redirect_uri=callback-url", request.getBody().readUtf8());
     }

--- a/src/test/java/cd/go/authorization/keycloak/KeycloakAuthorizerTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/KeycloakAuthorizerTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class KeycloakAuthorizerTest {

--- a/src/test/java/cd/go/authorization/keycloak/KeycloakUserTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/KeycloakUserTest.java
@@ -19,7 +19,7 @@ package cd.go.authorization.keycloak;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class KeycloakUserTest {
 

--- a/src/test/java/cd/go/authorization/keycloak/executors/AuthConfigValidateRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/AuthConfigValidateRequestExecutorTest.java
@@ -52,10 +52,6 @@ public class AuthConfigValidateRequestExecutorTest {
                 "    \"key\": \"KeycloakEndpoint\"\n" +
                 "  },\n" +
                 "  {\n" +
-                "    \"message\": \"KeycloakContextPath must not be blank.\",\n" +
-                "    \"key\": \"KeycloakContextPath\"\n" +
-                "  },\n" +
-                "  {\n" +
                 "    \"message\": \"KeycloakRealm must not be blank.\",\n" +
                 "    \"key\": \"KeycloakRealm\"\n" +
                 "  },\n" +

--- a/src/test/java/cd/go/authorization/keycloak/executors/AuthConfigValidateRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/AuthConfigValidateRequestExecutorTest.java
@@ -52,6 +52,10 @@ public class AuthConfigValidateRequestExecutorTest {
                 "    \"key\": \"KeycloakEndpoint\"\n" +
                 "  },\n" +
                 "  {\n" +
+                "    \"message\": \"KeycloakContextPath must not be blank.\",\n" +
+                "    \"key\": \"KeycloakContextPath\"\n" +
+                "  },\n" +
+                "  {\n" +
                 "    \"message\": \"KeycloakRealm must not be blank.\",\n" +
                 "    \"key\": \"KeycloakRealm\"\n" +
                 "  },\n" +
@@ -62,6 +66,10 @@ public class AuthConfigValidateRequestExecutorTest {
                 "  {\n" +
                 "    \"message\": \"ClientSecret must not be blank.\",\n" +
                 "    \"key\": \"ClientSecret\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"message\": \"KeycloakScopes must not be blank.\",\n" +
+                "    \"key\": \"KeycloakScopes\"\n" +
                 "  }\n" +
                 "]";
 

--- a/src/test/java/cd/go/authorization/keycloak/executors/FetchAccessTokenRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/FetchAccessTokenRequestExecutorTest.java
@@ -33,13 +33,12 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class FetchAccessTokenRequestExecutorTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
     @Mock
     private FetchAccessTokenRequest request;
     @Mock
@@ -64,10 +63,8 @@ public class FetchAccessTokenRequestExecutorTest {
     public void shouldErrorOutIfAuthConfigIsNotProvided() throws Exception {
         when(request.authConfigs()).thenReturn(Collections.emptyList());
 
-        thrown.expect(NoAuthorizationConfigurationException.class);
-        thrown.expectMessage("[Get Access Token] No authorization configuration found.");
-
-        executor.execute();
+        Throwable thrown = assertThrows(NoAuthorizationConfigurationException.class, () -> executor.execute());
+        assertThat(thrown.getMessage(), is("[Get Access Token] No authorization configuration found."));
     }
 
     @Test

--- a/src/test/java/cd/go/authorization/keycloak/executors/GetAuthConfigMetadataRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/GetAuthConfigMetadataRequestExecutorTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GetAuthConfigMetadataRequestExecutorTest {
 

--- a/src/test/java/cd/go/authorization/keycloak/executors/GetAuthConfigMetadataRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/GetAuthConfigMetadataRequestExecutorTest.java
@@ -52,13 +52,6 @@ public class GetAuthConfigMetadataRequestExecutorTest {
                 "    }\n" +
                 "  },\n" +
                 "  {\n" +
-                "    \"key\": \"KeycloakContextPath\",\n" +
-                "    \"metadata\": {\n" +
-                "      \"required\": true,\n" +
-                "      \"secure\": false\n" +
-                "    }\n" +
-                "  },\n" +
-                "  {\n" +
                 "    \"key\": \"KeycloakRealm\",\n" +
                 "    \"metadata\": {\n" +
                 "      \"required\": true,\n" +

--- a/src/test/java/cd/go/authorization/keycloak/executors/GetAuthConfigMetadataRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/GetAuthConfigMetadataRequestExecutorTest.java
@@ -52,6 +52,13 @@ public class GetAuthConfigMetadataRequestExecutorTest {
                 "    }\n" +
                 "  },\n" +
                 "  {\n" +
+                "    \"key\": \"KeycloakContextPath\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": true,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
                 "    \"key\": \"KeycloakRealm\",\n" +
                 "    \"metadata\": {\n" +
                 "      \"required\": true,\n" +
@@ -70,6 +77,13 @@ public class GetAuthConfigMetadataRequestExecutorTest {
                 "    \"metadata\": {\n" +
                 "      \"required\": true,\n" +
                 "      \"secure\": true\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"KeycloakScopes\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": true,\n" +
+                "      \"secure\": false\n" +
                 "    }\n" +
                 "  }\n" +
                 "]";

--- a/src/test/java/cd/go/authorization/keycloak/executors/GetAuthConfigViewRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/GetAuthConfigViewRequestExecutorTest.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GetAuthConfigViewRequestExecutorTest {
 

--- a/src/test/java/cd/go/authorization/keycloak/executors/GetAuthorizationServerUrlRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/GetAuthorizationServerUrlRequestExecutorTest.java
@@ -32,14 +32,12 @@ import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class GetAuthorizationServerUrlRequestExecutorTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
     @Mock
     private GetAuthorizationServerUrlRequest request;
     @Mock
@@ -62,10 +60,8 @@ public class GetAuthorizationServerUrlRequestExecutorTest {
     public void shouldErrorOutIfAuthConfigIsNotProvided() throws Exception {
         when(request.authConfigs()).thenReturn(Collections.emptyList());
 
-        thrown.expect(NoAuthorizationConfigurationException.class);
-        thrown.expectMessage("[Authorization Server Url] No authorization configuration found.");
-
-        executor.execute();
+        Throwable thrown = assertThrows(NoAuthorizationConfigurationException.class, () -> executor.execute());
+        assertThat(thrown.getMessage(), is("[Authorization Server Url] No authorization configuration found."));
     }
 
     @Test

--- a/src/test/java/cd/go/authorization/keycloak/executors/GetPluginIconRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/GetPluginIconRequestExecutorTest.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 
 import static java.util.Base64.getDecoder;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GetPluginIconRequestExecutorTest {
 

--- a/src/test/java/cd/go/authorization/keycloak/executors/GetRoleConfigMetadataRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/GetRoleConfigMetadataRequestExecutorTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GetRoleConfigMetadataRequestExecutorTest {
 

--- a/src/test/java/cd/go/authorization/keycloak/executors/GetRoleConfigViewRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/GetRoleConfigViewRequestExecutorTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GetRoleConfigViewRequestExecutorTest {
 

--- a/src/test/java/cd/go/authorization/keycloak/executors/UserAuthenticationRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/executors/UserAuthenticationRequestExecutorTest.java
@@ -34,14 +34,12 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class UserAuthenticationRequestExecutorTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
     @Mock
     private UserAuthenticationRequest request;
     @Mock
@@ -66,10 +64,8 @@ public class UserAuthenticationRequestExecutorTest {
     public void shouldErrorOutIfAuthConfigIsNotProvided() throws Exception {
         when(request.authConfigs()).thenReturn(Collections.emptyList());
 
-        thrown.expect(NoAuthorizationConfigurationException.class);
-        thrown.expectMessage("[Authenticate] No authorization configuration found.");
-
-        executor.execute();
+        Throwable thrown = assertThrows(NoAuthorizationConfigurationException.class, () -> executor.execute());
+        assertThat(thrown.getMessage(), is("[Authenticate] No authorization configuration found."));
     }
 
     @Test

--- a/src/test/java/cd/go/authorization/keycloak/models/KeycloakConfigurationTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/models/KeycloakConfigurationTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class KeycloakConfigurationTest {
 
@@ -32,13 +32,17 @@ public class KeycloakConfigurationTest {
     public void shouldDeserializeKeycloakConfiguration() throws Exception {
         final KeycloakConfiguration keycloakConfiguration = KeycloakConfiguration.fromJSON("{\n" +
                 "  \"KeycloakEndpoint\": \"https://example.co.in\",\n" +
+                "  \"KeycloakContextPath\": true,\n" +
                 "  \"ClientId\": \"client-id\",\n" +
-                "  \"ClientSecret\": \"client-secret\"\n" +
+                "  \"ClientSecret\": \"client-secret\",\n" +
+                "  \"KeycloakScopes\": \"openid profile email groups roles\"\n" +
                 "}");
 
         assertThat(keycloakConfiguration.keycloakEndpoint(), is("https://example.co.in"));
+        assertThat(keycloakConfiguration.keycloakContextPath(), is(true));
         assertThat(keycloakConfiguration.clientId(), is("client-id"));
         assertThat(keycloakConfiguration.clientSecret(), is("client-secret"));
+        assertThat(keycloakConfiguration.keycloakScopes(), is("openid profile email groups roles"));
     }
 
     @Test

--- a/src/test/java/cd/go/authorization/keycloak/models/KeycloakConfigurationTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/models/KeycloakConfigurationTest.java
@@ -32,14 +32,12 @@ public class KeycloakConfigurationTest {
     public void shouldDeserializeKeycloakConfiguration() throws Exception {
         final KeycloakConfiguration keycloakConfiguration = KeycloakConfiguration.fromJSON("{\n" +
                 "  \"KeycloakEndpoint\": \"https://example.co.in\",\n" +
-                "  \"KeycloakContextPath\": true,\n" +
                 "  \"ClientId\": \"client-id\",\n" +
                 "  \"ClientSecret\": \"client-secret\",\n" +
                 "  \"KeycloakScopes\": \"openid profile email groups roles\"\n" +
                 "}");
 
         assertThat(keycloakConfiguration.keycloakEndpoint(), is("https://example.co.in"));
-        assertThat(keycloakConfiguration.keycloakContextPath(), is(true));
         assertThat(keycloakConfiguration.clientId(), is("client-id"));
         assertThat(keycloakConfiguration.clientSecret(), is("client-secret"));
         assertThat(keycloakConfiguration.keycloakScopes(), is("openid profile email groups roles"));

--- a/src/test/java/cd/go/authorization/keycloak/models/TokenInfoTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/models/TokenInfoTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TokenInfoTest {
 

--- a/src/test/java/cd/go/authorization/keycloak/models/UserTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/models/UserTest.java
@@ -22,7 +22,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import static cd.go.authorization.keycloak.utils.Util.GSON;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class UserTest {
 

--- a/src/test/java/cd/go/authorization/keycloak/requests/AuthConfigValidateRequestTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/requests/AuthConfigValidateRequestTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 

--- a/src/test/java/cd/go/authorization/keycloak/requests/FetchAccessTokenRequestTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/requests/FetchAccessTokenRequestTest.java
@@ -26,8 +26,8 @@ import org.mockito.Mock;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 

--- a/src/test/java/cd/go/authorization/keycloak/requests/GetAuthorizationServerUrlRequestTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/requests/GetAuthorizationServerUrlRequestTest.java
@@ -26,8 +26,8 @@ import org.mockito.Mock;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 

--- a/src/test/java/cd/go/authorization/keycloak/requests/RoleConfigValidateRequestTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/requests/RoleConfigValidateRequestTest.java
@@ -24,7 +24,7 @@ import org.mockito.Mock;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 

--- a/src/test/java/cd/go/authorization/keycloak/requests/UserAuthenticationRequestTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/requests/UserAuthenticationRequestTest.java
@@ -26,8 +26,8 @@ import org.mockito.Mock;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 

--- a/src/test/java/cd/go/authorization/keycloak/requests/VerifyConnectionRequestTest.java
+++ b/src/test/java/cd/go/authorization/keycloak/requests/VerifyConnectionRequestTest.java
@@ -25,8 +25,8 @@ import org.mockito.Mock;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 


### PR DESCRIPTION
The plugin can set the utilization of Keycloak context path or not 
The scopes now can be set in the GoCD interface
Fix some tests